### PR TITLE
add 64bit nativeplatforms

### DIFF
--- a/proto.go
+++ b/proto.go
@@ -16,8 +16,10 @@ var DefaultConfig = Config{
    NativePlatform: []string{
       // com.vimeo.android.videoapp
       "x86",
+      "x86_64",
       // com.axis.drawingdesk.v3
       "armeabi-v7a",
+      "arm64-v8a",
    },
    SystemAvailableFeature: []string{
       // com.smarty.voomvoom


### PR DESCRIPTION
adds 64bit platforms to the generated device, allowing to download those versions of apps
without those platforms, trying to download 64bit apps results with `unsupported protocol scheme`